### PR TITLE
add mc2

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -8,6 +8,7 @@ PKG sattools
 PKG sattools-minisat
 PKG sattools-cryptominisat
 PKG ocaml-sat-solvers
+PKG mc2.core mc2.dimacs
 
 PKG oclock
 PKG dolmen

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # sat-bench
 A small repo to test and benchmark different sat solvers
 
-# Benchamrking solver
+# Benchmarking solver
 
 ## Building
 

--- a/_tags
+++ b/_tags
@@ -15,5 +15,6 @@ true: color(always)
         package(sattools-minisat),                            \
         package(sattools-cryptominisat),                      \
         package(ocaml-sat-solvers),                           \
-        package(aez)
+        package(aez), \
+        package(mc2.core), package(mc2.dimacs)
 

--- a/opam
+++ b/opam
@@ -1,0 +1,37 @@
+opam-version: "1.2"
+name: "sat-bench"
+license: "todo"
+version: "dev"
+author: ["Guillaume Bury"]
+maintainer: ["Guillaume Bury"]
+build: [
+    [make "all"]
+]
+install: [
+]
+remove: [
+]
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "oclock"
+  "dolmen"
+  "printbox"
+  "base-unix"
+  "msat"
+  "minisat"
+  "sattools"
+  "sattools-minisat"
+  "sattools-cryptominisat"
+  "ocaml-sat-solvers"
+  "aez"
+  "mc2"
+]
+available: [
+  ocaml-version >= "4.03.0"
+]
+tags: [ "sat" "bench" ]
+homepage: "https://github.com/gbury/sat-bench"
+dev-repo: "https://github.com/gbury/sat-bench.git"
+bug-reports: "https://github.com/gbury/sat-bench/issues/"
+

--- a/src/main.ml
+++ b/src/main.ml
@@ -52,6 +52,25 @@ let msat =
     pre; solve;
   }
 
+(* mc² *)
+let mc2 =
+  let open Mc2_core in
+  let pre clauses =
+    let solver = Solver.create ~plugins:[Mc2_dimacs.Plugin_sat.plugin] () in
+    let mk_atom = Solver.get_service_exn solver Mc2_dimacs.Plugin_sat.k_atom in
+    solver, map (map mk_atom) clauses
+  in
+  let solve (solver,clauses) =
+    Solver.assume solver clauses;
+    match Solver.solve solver with
+      | Solver.Sat _ -> Sat
+      | Solver.Unsat _ -> Unsat
+  in {
+    name = "mc2";
+    package = "mc2.core, mc2.dimacs";
+    pre; solve;
+  }
+
 (* aez *)
 let aez =
   let () = Aez.Smt.set_cc false in
@@ -327,6 +346,7 @@ module P = Dolmen.Dimacs.Make
 let solver_list = [
   S aez;
   S msat;
+  S mc2;
   S (minisat false);
   S (ocaml_sat_solvers "minisat");
   S (sattools "minisat" "mini");


### PR DESCRIPTION
To install mc2: `opam pin add mc2 https://github.com/c-cube/mc2` with a recent flambda compiler and menhir.